### PR TITLE
Added shift method

### DIFF
--- a/pybboxes/types/albumentations_bounding_box.py
+++ b/pybboxes/types/albumentations_bounding_box.py
@@ -54,9 +54,9 @@ class AlbumentationsBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         horizontal_threshold, vertical_threshold = threshold
-        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        x_tl, y_tl, x_br, y_br = self.values
 
-        return AlbumentationsBoundingBox.from_voc(
+        return AlbumentationsBoundingBox(
             x_tl + horizontal_threshold,
             y_tl + vertical_threshold,
             x_br + horizontal_threshold,

--- a/pybboxes/types/albumentations_bounding_box.py
+++ b/pybboxes/types/albumentations_bounding_box.py
@@ -55,9 +55,15 @@ class AlbumentationsBoundingBox(BaseBoundingBox):
         """
         horizontal_threshold, vertical_threshold = threshold
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
-        
-        return AlbumentationsBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
 
+        return AlbumentationsBoundingBox.from_voc(
+            x_tl + horizontal_threshold,
+            y_tl + vertical_threshold,
+            x_br + horizontal_threshold,
+            y_br + vertical_threshold,
+            self.image_size,
+            self.strict,
+        )
 
     @classmethod
     def from_voc(

--- a/pybboxes/types/albumentations_bounding_box.py
+++ b/pybboxes/types/albumentations_bounding_box.py
@@ -34,6 +34,28 @@ class AlbumentationsBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
+    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "AlbumentationsBoundingBox":
+        """Returns a new bounding box shifted by the given thresholds. The new
+        bounding box has same image shape, and other properties as the current
+        object.
+
+        Parameters
+        ----------
+        horizontal_threshold : float
+            The amount to be shifted in the horizontal axis.
+        vertical_threshold : float
+            The amount to be shifted in the vertical axis.
+
+        Returns
+        -------
+        AlbumentationsBoundingBox
+            The new bounding box.
+        """
+        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        
+        return AlbumentationsBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
+
+
     @classmethod
     def from_voc(
         cls,

--- a/pybboxes/types/albumentations_bounding_box.py
+++ b/pybboxes/types/albumentations_bounding_box.py
@@ -1,7 +1,5 @@
 from typing import Tuple, Union
 
-from cv2 import threshold
-
 from pybboxes.types.base import BaseBoundingBox
 from pybboxes.types.bbox import BoundingBox
 
@@ -36,14 +34,14 @@ class AlbumentationsBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, threshold: Tuple[int, int]) -> "AlbumentationsBoundingBox":
+    def shift(self, amount: Tuple[float, float]) -> "AlbumentationsBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        threshold: Tuple[int, int]
+        amount: Tuple[float, float]
             The amount to shift the bounding box. The first value is the
                 amount to shift the x-coordinate, and the second value is the
                 amount to shift the y-coordinate.
@@ -53,7 +51,7 @@ class AlbumentationsBoundingBox(BaseBoundingBox):
         AlbumentationsBoundingBox
             The new bounding box.
         """
-        horizontal_threshold, vertical_threshold = threshold
+        horizontal_threshold, vertical_threshold = amount
         x_tl, y_tl, x_br, y_br = self.values
 
         return AlbumentationsBoundingBox(

--- a/pybboxes/types/albumentations_bounding_box.py
+++ b/pybboxes/types/albumentations_bounding_box.py
@@ -51,14 +51,14 @@ class AlbumentationsBoundingBox(BaseBoundingBox):
         AlbumentationsBoundingBox
             The new bounding box.
         """
-        horizontal_threshold, vertical_threshold = amount
+        horizontal_shift, vertical_shift = amount
         x_tl, y_tl, x_br, y_br = self.values
 
         return AlbumentationsBoundingBox(
-            x_tl + horizontal_threshold,
-            y_tl + vertical_threshold,
-            x_br + horizontal_threshold,
-            y_br + vertical_threshold,
+            x_tl + horizontal_shift,
+            y_tl + vertical_shift,
+            x_br + horizontal_shift,
+            y_br + vertical_shift,
             self.image_size,
             self.strict,
         )

--- a/pybboxes/types/albumentations_bounding_box.py
+++ b/pybboxes/types/albumentations_bounding_box.py
@@ -1,5 +1,7 @@
 from typing import Tuple, Union
 
+from cv2 import threshold
+
 from pybboxes.types.base import BaseBoundingBox
 from pybboxes.types.bbox import BoundingBox
 
@@ -34,23 +36,24 @@ class AlbumentationsBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "AlbumentationsBoundingBox":
+    def shift(self, threshold: Tuple[int, int]) -> "AlbumentationsBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        horizontal_threshold : float
-            The amount to be shifted in the horizontal axis.
-        vertical_threshold : float
-            The amount to be shifted in the vertical axis.
+        threshold: Tuple[int, int]
+            The amount to shift the bounding box. The first value is the
+                amount to shift the x-coordinate, and the second value is the
+                amount to shift the y-coordinate.
 
         Returns
         -------
         AlbumentationsBoundingBox
             The new bounding box.
         """
+        horizontal_threshold, vertical_threshold = threshold
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
         
         return AlbumentationsBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)

--- a/pybboxes/types/base.py
+++ b/pybboxes/types/base.py
@@ -117,6 +117,10 @@ class BaseBoundingBox(Box, ABC):
 
     def to_yolo(self, return_values: bool = False) -> Union[Tuple[int, int, int, int], "BaseBoundingBox"]:
         return self.to_voc().to_yolo(return_values)
+    
+    @abstractmethod
+    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "BaseBoundingBox":
+        pass
 
     @classmethod
     @abstractmethod

--- a/pybboxes/types/base.py
+++ b/pybboxes/types/base.py
@@ -119,7 +119,19 @@ class BaseBoundingBox(Box, ABC):
         return self.to_voc().to_yolo(return_values)
     
     @abstractmethod
-    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "BaseBoundingBox":
+    def shift(self, threshold: Tuple[int, int]) -> "BaseBoundingBox":
+        """Perform a shift operation on the bounding box, and return a new bounding
+        box. 
+        
+        Args:
+            threshold: The amount to shift the bounding box. The first value is the
+                amount to shift the x-coordinate, and the second value is the
+                amount to shift the y-coordinate.
+        """
+        pass
+
+    @abstractmethod
+    def scale(self, horizontal_factor: float, vertical_factor: float) -> "BaseBoundingBox":
         pass
 
     @classmethod

--- a/pybboxes/types/base.py
+++ b/pybboxes/types/base.py
@@ -118,7 +118,7 @@ class BaseBoundingBox(Box, ABC):
     def to_yolo(self, return_values: bool = False) -> Union[Tuple[int, int, int, int], "BaseBoundingBox"]:
         return self.to_voc().to_yolo(return_values)
 
-    @abstractmethod
+    # @abstractmethod
     def shift(self, threshold: Tuple[int, int]) -> "BaseBoundingBox":
         """Perform a shift operation on the bounding box, and return a new bounding
         box.
@@ -128,10 +128,6 @@ class BaseBoundingBox(Box, ABC):
                 amount to shift the x-coordinate, and the second value is the
                 amount to shift the y-coordinate.
         """
-        pass
-
-    @abstractmethod
-    def scale(self, horizontal_factor: float, vertical_factor: float) -> "BaseBoundingBox":
         pass
 
     @classmethod

--- a/pybboxes/types/base.py
+++ b/pybboxes/types/base.py
@@ -117,12 +117,12 @@ class BaseBoundingBox(Box, ABC):
 
     def to_yolo(self, return_values: bool = False) -> Union[Tuple[int, int, int, int], "BaseBoundingBox"]:
         return self.to_voc().to_yolo(return_values)
-    
+
     @abstractmethod
     def shift(self, threshold: Tuple[int, int]) -> "BaseBoundingBox":
         """Perform a shift operation on the bounding box, and return a new bounding
-        box. 
-        
+        box.
+
         Args:
             threshold: The amount to shift the bounding box. The first value is the
                 amount to shift the x-coordinate, and the second value is the

--- a/pybboxes/types/bbox.py
+++ b/pybboxes/types/bbox.py
@@ -73,13 +73,13 @@ class BoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, x_br, y_br = self.values
-        horizontal_threshold, vertical_threshold = amount
+        horizontal_shift, vertical_shift = amount
 
         return BoundingBox(
-            x_tl + horizontal_threshold,
-            y_tl + vertical_threshold,
-            x_br + horizontal_threshold,
-            y_br + vertical_threshold,
+            x_tl + horizontal_shift,
+            y_tl + vertical_shift,
+            x_br + horizontal_shift,
+            y_br + vertical_shift,
             self.image_size,
             self.strict,
         )

--- a/pybboxes/types/bbox.py
+++ b/pybboxes/types/bbox.py
@@ -55,6 +55,35 @@ class BoundingBox(BaseBoundingBox):
                 "Top-left axes cannot be negative. To silently skip out of bounds cases pass 'strict=False'."
             )
 
+    def shift(self, amount: Tuple[float, float]) -> "BoundingBox":
+        """Returns a new bounding box shifted by the given thresholds. The new
+        bounding box has same image shape, and other properties as the current
+        object.
+
+        Parameters
+        ----------
+        amount: Tuple[float, float]
+            The amount to shift the bounding box. The first value is the
+                amount to shift the x-coordinate, and the second value is the
+                amount to shift the y-coordinate.
+
+        Returns
+        -------
+        BoundingBox
+            The new bounding box.
+        """
+        x_tl, y_tl, x_br, y_br = self.values
+        horizontal_threshold, vertical_threshold = amount
+
+        return BoundingBox(
+            x_tl + horizontal_threshold,
+            y_tl + vertical_threshold,
+            x_br + horizontal_threshold,
+            y_br + vertical_threshold,
+            self.image_size,
+            self.strict,
+        )
+
     def _to_bbox_type(self, name: str, return_values: bool) -> BaseBoundingBox:
         return load_bbox(
             name, values=self.values, image_size=self.image_size, return_values=return_values, from_voc=True

--- a/pybboxes/types/coco_bounding_box.py
+++ b/pybboxes/types/coco_bounding_box.py
@@ -57,10 +57,10 @@ class CocoBoundingBox(BaseBoundingBox):
         CocoBoundingBox
             The new bounding box.
         """
-        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        x_tl, y_tl, x_br, y_br = self.values
         horizontal_threshold, vertical_threshold = threshold
 
-        return CocoBoundingBox.from_voc(
+        return CocoBoundingBox(
             x_tl + horizontal_threshold,
             y_tl + vertical_threshold,
             x_br + horizontal_threshold,

--- a/pybboxes/types/coco_bounding_box.py
+++ b/pybboxes/types/coco_bounding_box.py
@@ -39,17 +39,17 @@ class CocoBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
     
-    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "CocoBoundingBox":
+    def shift(self, threshold: Tuple[int, int]) -> "CocoBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        horizontal_threshold : float
-            The amount to be shifted in the horizontal axis.
-        vertical_threshold : float
-            The amount to be shifted in the vertical axis.
+        threshold: Tuple[int, int]
+            The amount to shift the bounding box. The first value is the
+                amount to shift the x-coordinate, and the second value is the
+                amount to shift the y-coordinate.
 
         Returns
         -------
@@ -57,7 +57,8 @@ class CocoBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
-        
+        horizontal_threshold, vertical_threshold = threshold
+
         return CocoBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
 
     @classmethod

--- a/pybboxes/types/coco_bounding_box.py
+++ b/pybboxes/types/coco_bounding_box.py
@@ -3,8 +3,6 @@ from typing import Tuple, Union
 from pybboxes.types.base import BaseBoundingBox
 from pybboxes.types.bbox import BoundingBox
 
-# from pybboxes.functional import convert_bbox
-
 
 class CocoBoundingBox(BaseBoundingBox):
     def __init__(
@@ -40,14 +38,14 @@ class CocoBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, threshold: Tuple[int, int]) -> "CocoBoundingBox":
+    def shift(self, amount: Tuple[int, int]) -> "CocoBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        threshold: Tuple[int, int]
+        amount: Tuple[int, int]
             The amount to shift the bounding box. The first value is the
                 amount to shift the x-coordinate, and the second value is the
                 amount to shift the y-coordinate.
@@ -58,7 +56,7 @@ class CocoBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, w, h = self.values
-        horizontal_threshold, vertical_threshold = threshold
+        horizontal_threshold, vertical_threshold = amount
 
         return CocoBoundingBox(
             x_tl + horizontal_threshold,

--- a/pybboxes/types/coco_bounding_box.py
+++ b/pybboxes/types/coco_bounding_box.py
@@ -2,6 +2,7 @@ from typing import Tuple, Union
 
 from pybboxes.types.base import BaseBoundingBox
 from pybboxes.types.bbox import BoundingBox
+from pybboxes.functional import convert_bbox
 
 
 class CocoBoundingBox(BaseBoundingBox):
@@ -37,6 +38,27 @@ class CocoBoundingBox(BaseBoundingBox):
         if return_values:
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
+    
+    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "CocoBoundingBox":
+        """Returns a new bounding box shifted by the given thresholds. The new
+        bounding box has same image shape, and other properties as the current
+        object.
+
+        Parameters
+        ----------
+        horizontal_threshold : float
+            The amount to be shifted in the horizontal axis.
+        vertical_threshold : float
+            The amount to be shifted in the vertical axis.
+
+        Returns
+        -------
+        CocoBoundingBox
+            The new bounding box.
+        """
+        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        
+        return CocoBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
 
     @classmethod
     def from_voc(

--- a/pybboxes/types/coco_bounding_box.py
+++ b/pybboxes/types/coco_bounding_box.py
@@ -57,14 +57,14 @@ class CocoBoundingBox(BaseBoundingBox):
         CocoBoundingBox
             The new bounding box.
         """
-        x_tl, y_tl, x_br, y_br = self.values
+        x_tl, y_tl, w, h = self.values
         horizontal_threshold, vertical_threshold = threshold
 
         return CocoBoundingBox(
             x_tl + horizontal_threshold,
             y_tl + vertical_threshold,
-            x_br + horizontal_threshold,
-            y_br + vertical_threshold,
+            w,
+            h,
             self.image_size,
             self.strict,
         )

--- a/pybboxes/types/coco_bounding_box.py
+++ b/pybboxes/types/coco_bounding_box.py
@@ -56,11 +56,11 @@ class CocoBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, w, h = self.values
-        horizontal_threshold, vertical_threshold = amount
+        horizontal_shift, vertical_shift = amount
 
         return CocoBoundingBox(
-            x_tl + horizontal_threshold,
-            y_tl + vertical_threshold,
+            x_tl + horizontal_shift,
+            y_tl + vertical_shift,
             w,
             h,
             self.image_size,

--- a/pybboxes/types/coco_bounding_box.py
+++ b/pybboxes/types/coco_bounding_box.py
@@ -2,7 +2,8 @@ from typing import Tuple, Union
 
 from pybboxes.types.base import BaseBoundingBox
 from pybboxes.types.bbox import BoundingBox
-from pybboxes.functional import convert_bbox
+
+# from pybboxes.functional import convert_bbox
 
 
 class CocoBoundingBox(BaseBoundingBox):
@@ -38,7 +39,7 @@ class CocoBoundingBox(BaseBoundingBox):
         if return_values:
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
-    
+
     def shift(self, threshold: Tuple[int, int]) -> "CocoBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
@@ -59,7 +60,14 @@ class CocoBoundingBox(BaseBoundingBox):
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
         horizontal_threshold, vertical_threshold = threshold
 
-        return CocoBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
+        return CocoBoundingBox.from_voc(
+            x_tl + horizontal_threshold,
+            y_tl + vertical_threshold,
+            x_br + horizontal_threshold,
+            y_br + vertical_threshold,
+            self.image_size,
+            self.strict,
+        )
 
     @classmethod
     def from_voc(

--- a/pybboxes/types/fiftyone_bounding_box.py
+++ b/pybboxes/types/fiftyone_bounding_box.py
@@ -55,9 +55,15 @@ class FiftyoneBoundingBox(BaseBoundingBox):
         """
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
         horizontal_threshold, vertical_threshold = threshold
-        
-        return FiftyoneBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
 
+        return FiftyoneBoundingBox.from_voc(
+            x_tl + horizontal_threshold,
+            y_tl + vertical_threshold,
+            x_br + horizontal_threshold,
+            y_br + vertical_threshold,
+            self.image_size,
+            self.strict,
+        )
 
     @classmethod
     def from_voc(

--- a/pybboxes/types/fiftyone_bounding_box.py
+++ b/pybboxes/types/fiftyone_bounding_box.py
@@ -36,14 +36,14 @@ class FiftyoneBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, threshold: Tuple[float, float]) -> "FiftyoneBoundingBox":
+    def shift(self, amount: Tuple[float, float]) -> "FiftyoneBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        threshold: Tuple[float, float]
+        amount: Tuple[float, float]
             The amount to shift the bounding box. The first value is the
                 amount to shift the x-coordinate, and the second value is the
                 amount to shift the y-coordinate.
@@ -54,7 +54,7 @@ class FiftyoneBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, w, h = self.values
-        horizontal_threshold, vertical_threshold = threshold
+        horizontal_threshold, vertical_threshold = amount
 
         return FiftyoneBoundingBox(
             x_tl + horizontal_threshold,

--- a/pybboxes/types/fiftyone_bounding_box.py
+++ b/pybboxes/types/fiftyone_bounding_box.py
@@ -36,14 +36,14 @@ class FiftyoneBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, threshold: Tuple[int, int]) -> "FiftyoneBoundingBox":
+    def shift(self, threshold: Tuple[float, float]) -> "FiftyoneBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        threshold: Tuple[int, int]
+        threshold: Tuple[float, float]
             The amount to shift the bounding box. The first value is the
                 amount to shift the x-coordinate, and the second value is the
                 amount to shift the y-coordinate.
@@ -53,14 +53,14 @@ class FiftyoneBoundingBox(BaseBoundingBox):
         FiftyoneBoundingBox
             The new bounding box.
         """
-        x_tl, y_tl, x_br, y_br = self.values
+        x_tl, y_tl, w, h = self.values
         horizontal_threshold, vertical_threshold = threshold
 
         return FiftyoneBoundingBox(
             x_tl + horizontal_threshold,
             y_tl + vertical_threshold,
-            x_br + horizontal_threshold,
-            y_br + vertical_threshold,
+            w,
+            h,
             self.image_size,
             self.strict,
         )

--- a/pybboxes/types/fiftyone_bounding_box.py
+++ b/pybboxes/types/fiftyone_bounding_box.py
@@ -54,11 +54,11 @@ class FiftyoneBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, w, h = self.values
-        horizontal_threshold, vertical_threshold = amount
+        horizontal_shift, vertical_shift = amount
 
         return FiftyoneBoundingBox(
-            x_tl + horizontal_threshold,
-            y_tl + vertical_threshold,
+            x_tl + horizontal_shift,
+            y_tl + vertical_shift,
             w,
             h,
             self.image_size,

--- a/pybboxes/types/fiftyone_bounding_box.py
+++ b/pybboxes/types/fiftyone_bounding_box.py
@@ -53,10 +53,10 @@ class FiftyoneBoundingBox(BaseBoundingBox):
         FiftyoneBoundingBox
             The new bounding box.
         """
-        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        x_tl, y_tl, x_br, y_br = self.values
         horizontal_threshold, vertical_threshold = threshold
 
-        return FiftyoneBoundingBox.from_voc(
+        return FiftyoneBoundingBox(
             x_tl + horizontal_threshold,
             y_tl + vertical_threshold,
             x_br + horizontal_threshold,

--- a/pybboxes/types/fiftyone_bounding_box.py
+++ b/pybboxes/types/fiftyone_bounding_box.py
@@ -36,17 +36,17 @@ class FiftyoneBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "FiftyoneBoundingBox":
+    def shift(self, threshold: Tuple[int, int]) -> "FiftyoneBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        horizontal_threshold : float
-            The amount to be shifted in the horizontal axis.
-        vertical_threshold : float
-            The amount to be shifted in the vertical axis.
+        threshold: Tuple[int, int]
+            The amount to shift the bounding box. The first value is the
+                amount to shift the x-coordinate, and the second value is the
+                amount to shift the y-coordinate.
 
         Returns
         -------
@@ -54,6 +54,7 @@ class FiftyoneBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        horizontal_threshold, vertical_threshold = threshold
         
         return FiftyoneBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
 

--- a/pybboxes/types/fiftyone_bounding_box.py
+++ b/pybboxes/types/fiftyone_bounding_box.py
@@ -36,6 +36,28 @@ class FiftyoneBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
+    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "FiftyoneBoundingBox":
+        """Returns a new bounding box shifted by the given thresholds. The new
+        bounding box has same image shape, and other properties as the current
+        object.
+
+        Parameters
+        ----------
+        horizontal_threshold : float
+            The amount to be shifted in the horizontal axis.
+        vertical_threshold : float
+            The amount to be shifted in the vertical axis.
+
+        Returns
+        -------
+        FiftyoneBoundingBox
+            The new bounding box.
+        """
+        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        
+        return FiftyoneBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
+
+
     @classmethod
     def from_voc(
         cls,

--- a/pybboxes/types/yolo_bounding_box.py
+++ b/pybboxes/types/yolo_bounding_box.py
@@ -56,11 +56,11 @@ class YoloBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, w, h = self.values
-        horizontal_threshold, vertical_threshold = amount
+        horizontal_shift, vertical_shift = amount
 
         return YoloBoundingBox(
-            x_tl + horizontal_threshold,
-            y_tl + vertical_threshold,
+            x_tl + horizontal_shift,
+            y_tl + vertical_shift,
             w,
             h,
             self.image_size,

--- a/pybboxes/types/yolo_bounding_box.py
+++ b/pybboxes/types/yolo_bounding_box.py
@@ -38,6 +38,28 @@ class YoloBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
+    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "YoloBoundingBox":
+        """Returns a new bounding box shifted by the given thresholds. The new
+        bounding box has same image shape, and other properties as the current
+        object.
+
+        Parameters
+        ----------
+        horizontal_threshold : float
+            The amount to be shifted in the horizontal axis.
+        vertical_threshold : float
+            The amount to be shifted in the vertical axis.
+
+        Returns
+        -------
+        YoloBoundingBox
+            The new bounding box.
+        """
+        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        
+        return YoloBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
+
+
     @classmethod
     def from_voc(
         cls,

--- a/pybboxes/types/yolo_bounding_box.py
+++ b/pybboxes/types/yolo_bounding_box.py
@@ -38,17 +38,17 @@ class YoloBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, horizontal_threshold: float, vertical_threshold: float) -> "YoloBoundingBox":
+    def shift(self, threshold: Tuple[int, int]) -> "YoloBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        horizontal_threshold : float
-            The amount to be shifted in the horizontal axis.
-        vertical_threshold : float
-            The amount to be shifted in the vertical axis.
+        threshold: Tuple[int, int]
+            The amount to shift the bounding box. The first value is the
+                amount to shift the x-coordinate, and the second value is the
+                amount to shift the y-coordinate.
 
         Returns
         -------
@@ -56,6 +56,7 @@ class YoloBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        horizontal_threshold, vertical_threshold = threshold
         
         return YoloBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
 

--- a/pybboxes/types/yolo_bounding_box.py
+++ b/pybboxes/types/yolo_bounding_box.py
@@ -38,14 +38,14 @@ class YoloBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, threshold: Tuple[int, int]) -> "YoloBoundingBox":
+    def shift(self, threshold: Tuple[float, float]) -> "YoloBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        threshold: Tuple[int, int]
+        threshold: Tuple[float, float]
             The amount to shift the bounding box. The first value is the
                 amount to shift the x-coordinate, and the second value is the
                 amount to shift the y-coordinate.

--- a/pybboxes/types/yolo_bounding_box.py
+++ b/pybboxes/types/yolo_bounding_box.py
@@ -57,9 +57,15 @@ class YoloBoundingBox(BaseBoundingBox):
         """
         x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
         horizontal_threshold, vertical_threshold = threshold
-        
-        return YoloBoundingBox.from_voc(x_tl + horizontal_threshold, y_tl + vertical_threshold, x_br + horizontal_threshold, y_br + vertical_threshold, self.image_size, self.strict)
 
+        return YoloBoundingBox.from_voc(
+            x_tl + horizontal_threshold,
+            y_tl + vertical_threshold,
+            x_br + horizontal_threshold,
+            y_br + vertical_threshold,
+            self.image_size,
+            self.strict,
+        )
 
     @classmethod
     def from_voc(

--- a/pybboxes/types/yolo_bounding_box.py
+++ b/pybboxes/types/yolo_bounding_box.py
@@ -55,14 +55,14 @@ class YoloBoundingBox(BaseBoundingBox):
         YoloBoundingBox
             The new bounding box.
         """
-        x_tl, y_tl, x_br, y_br = self.to_voc(return_values=True)
+        x_tl, y_tl, w, h = self.values
         horizontal_threshold, vertical_threshold = threshold
 
-        return YoloBoundingBox.from_voc(
+        return YoloBoundingBox(
             x_tl + horizontal_threshold,
             y_tl + vertical_threshold,
-            x_br + horizontal_threshold,
-            y_br + vertical_threshold,
+            w,
+            h,
             self.image_size,
             self.strict,
         )

--- a/pybboxes/types/yolo_bounding_box.py
+++ b/pybboxes/types/yolo_bounding_box.py
@@ -38,14 +38,14 @@ class YoloBoundingBox(BaseBoundingBox):
             return x_tl, y_tl, x_br, y_br
         return BoundingBox(x_tl, y_tl, x_br, y_br, image_size=self.image_size, strict=self.strict)
 
-    def shift(self, threshold: Tuple[float, float]) -> "YoloBoundingBox":
+    def shift(self, amount: Tuple[float, float]) -> "YoloBoundingBox":
         """Returns a new bounding box shifted by the given thresholds. The new
         bounding box has same image shape, and other properties as the current
         object.
 
         Parameters
         ----------
-        threshold: Tuple[float, float]
+        amount: Tuple[float, float]
             The amount to shift the bounding box. The first value is the
                 amount to shift the x-coordinate, and the second value is the
                 amount to shift the y-coordinate.
@@ -56,7 +56,7 @@ class YoloBoundingBox(BaseBoundingBox):
             The new bounding box.
         """
         x_tl, y_tl, w, h = self.values
-        horizontal_threshold, vertical_threshold = threshold
+        horizontal_threshold, vertical_threshold = amount
 
         return YoloBoundingBox(
             x_tl + horizontal_threshold,

--- a/tests/pybboxes/conftest.py
+++ b/tests/pybboxes/conftest.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 import pytest
 
-
 from tests.pybboxes import EXPECTED_OUTPUTS
 from tests.utils import load_json
 
@@ -38,7 +37,7 @@ def unnormalized_bbox_shift_amount():
 def normalized_bbox_shift_amount():
     return (0.05, 0.03)
 
-    
+
 @pytest.fixture(scope="package")
 def coco_bbox():
     return [98, 345, 322, 117]

--- a/tests/pybboxes/conftest.py
+++ b/tests/pybboxes/conftest.py
@@ -31,7 +31,7 @@ def albumentations_bbox():
 
 @pytest.fixture(scope="package")
 def bbox_shift_amount():
-    return (0.05, 0.05)
+    return (2, 2)
 
 
 @pytest.fixture(scope="package")

--- a/tests/pybboxes/conftest.py
+++ b/tests/pybboxes/conftest.py
@@ -8,6 +8,7 @@ import os
 from typing import Optional
 
 import pytest
+from sentry_sdk import Scope
 
 from tests.pybboxes import EXPECTED_OUTPUTS
 from tests.utils import load_json
@@ -26,6 +27,11 @@ def bbox_area():
 @pytest.fixture(scope="package")
 def albumentations_bbox():
     return [0.153125, 0.71875, 0.65625, 0.9625]
+
+
+@pytest.fixture(scope="package")
+def bbox_shift_amount():
+    return (0.05, 0.05)
 
 
 @pytest.fixture(scope="package")

--- a/tests/pybboxes/conftest.py
+++ b/tests/pybboxes/conftest.py
@@ -8,7 +8,7 @@ import os
 from typing import Optional
 
 import pytest
-from sentry_sdk import Scope
+
 
 from tests.pybboxes import EXPECTED_OUTPUTS
 from tests.utils import load_json

--- a/tests/pybboxes/conftest.py
+++ b/tests/pybboxes/conftest.py
@@ -30,10 +30,15 @@ def albumentations_bbox():
 
 
 @pytest.fixture(scope="package")
-def bbox_shift_amount():
+def unnormalized_bbox_shift_amount():
     return (2, 2)
 
 
+@pytest.fixture(scope="package")
+def normalized_bbox_shift_amount():
+    return (0.05, 0.03)
+
+    
 @pytest.fixture(scope="package")
 def coco_bbox():
     return [98, 345, 322, 117]

--- a/tests/pybboxes/types/test_albumentations_bounding_box.py
+++ b/tests/pybboxes/types/test_albumentations_bounding_box.py
@@ -45,7 +45,7 @@ def test_shift(albumentations_bounding_box, bbox_shift_amount):
         y_br + bbox_shift_amount[1],
     ]
 
-    assert_almost_equal(actual=actual_output.values, desired=desired)
+    assert_almost_equal(actual=list(actual_output.values), desired=desired)
 
 
 def test_to_fiftyone(albumentations_bounding_box, fiftyone_bbox):

--- a/tests/pybboxes/types/test_albumentations_bounding_box.py
+++ b/tests/pybboxes/types/test_albumentations_bounding_box.py
@@ -34,15 +34,15 @@ def test_to_coco(albumentations_bounding_box, coco_bbox):
     assert_almost_equal(actual=list(alb2coco_bbox.values), desired=coco_bbox)
 
 
-def test_shift(albumentations_bounding_box, bbox_shift_amount):
-    actual_output = albumentations_bounding_box.shift(bbox_shift_amount)
+def test_shift(albumentations_bounding_box, normalized_bbox_shift_amount):
+    actual_output = albumentations_bounding_box.shift(normalized_bbox_shift_amount)
 
     x_tl, y_tl, x_br, y_br = albumentations_bounding_box.values
     desired = [
-        x_tl + bbox_shift_amount[0],
-        y_tl + bbox_shift_amount[1],
-        x_br + bbox_shift_amount[0],
-        y_br + bbox_shift_amount[1],
+        x_tl + normalized_bbox_shift_amount[0],
+        y_tl + normalized_bbox_shift_amount[1],
+        x_br + normalized_bbox_shift_amount[0],
+        y_br + normalized_bbox_shift_amount[1],
     ]
 
     assert_almost_equal(actual=list(actual_output.values), desired=desired)

--- a/tests/pybboxes/types/test_albumentations_bounding_box.py
+++ b/tests/pybboxes/types/test_albumentations_bounding_box.py
@@ -34,6 +34,20 @@ def test_to_coco(albumentations_bounding_box, coco_bbox):
     assert_almost_equal(actual=list(alb2coco_bbox.values), desired=coco_bbox)
 
 
+def test_shift(albumentations_bounding_box, bbox_shift_amount):
+    actual_output = albumentations_bounding_box.shift(bbox_shift_amount)
+
+    x_tl, y_tl, x_br, y_br = albumentations_bounding_box.values
+    desired = [
+        x_tl + bbox_shift_amount[0],
+        y_tl + bbox_shift_amount[1],
+        x_br + bbox_shift_amount[0],
+        y_br + bbox_shift_amount[1],
+    ]
+
+    assert_almost_equal(actual=actual_output.values, desired=desired)
+
+
 def test_to_fiftyone(albumentations_bounding_box, fiftyone_bbox):
     alb2fiftyone_bbox = albumentations_bounding_box.to_fiftyone()
     assert_almost_equal(actual=list(alb2fiftyone_bbox.values), desired=fiftyone_bbox)

--- a/tests/pybboxes/types/test_coco_bounding_box.py
+++ b/tests/pybboxes/types/test_coco_bounding_box.py
@@ -29,13 +29,13 @@ def coco_area_computations_expected_output():
     }
 
 
-def test_shift(coco_bounding_box, bbox_shift_amount):
-    actual_output = coco_bounding_box.shift(bbox_shift_amount)
+def test_shift(coco_bounding_box, unnormalized_bbox_shift_amount):
+    actual_output = coco_bounding_box.shift(unnormalized_bbox_shift_amount)
 
     x_tl, y_tl, w, h = list(coco_bounding_box.values)
-    desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
+    desired = (x_tl + unnormalized_bbox_shift_amount[0], y_tl + unnormalized_bbox_shift_amount[1], w, h)
 
-    assert_almost_equal(actual=list(actual_output.values), desired=desired)
+    assert_almost_equal(actual=list(actual_output.values), desired=list(desired))
 
 
 def test_to_coco(coco_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_coco_bounding_box.py
+++ b/tests/pybboxes/types/test_coco_bounding_box.py
@@ -37,10 +37,10 @@ def test_shift(coco_bounding_box, unnormalized_bbox_shift_amount):
 
     assert_almost_equal(actual=list(actual_output.values), desired=list(desired))
 
+
 def test_from_array(coco_bbox, image_size):
     with pytest.warns(FutureWarning):
         CocoBoundingBox.from_array(coco_bbox, image_size=image_size)
-
 
 
 def test_to_coco(coco_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_coco_bounding_box.py
+++ b/tests/pybboxes/types/test_coco_bounding_box.py
@@ -32,10 +32,10 @@ def coco_area_computations_expected_output():
 def test_shift(coco_bounding_box, bbox_shift_amount):
     actual_output = coco_bounding_box.shift(bbox_shift_amount)
 
-    x_tl, y_tl, w, h = coco_bounding_box.values
+    x_tl, y_tl, w, h = list(coco_bounding_box.values)
     desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
 
-    assert_almost_equal(actual=actual_output.values, desired=desired)
+    assert_almost_equal(actual=list(actual_output.values), desired=desired)
 
 
 def test_to_coco(coco_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_coco_bounding_box.py
+++ b/tests/pybboxes/types/test_coco_bounding_box.py
@@ -29,6 +29,15 @@ def coco_area_computations_expected_output():
     }
 
 
+def test_shift(coco_bounding_box, bbox_shift_amount):
+    actual_output = coco_bounding_box.shift(bbox_shift_amount)
+
+    x_tl, y_tl, w, h = coco_bounding_box.values
+    desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
+
+    assert_almost_equal(actual=actual_output.values, desired=desired)
+
+
 def test_to_coco(coco_bounding_box, albumentations_bbox):
     coco2albumentations_bbox = coco_bounding_box.to_albumentations()
     assert_almost_equal(actual=list(coco2albumentations_bbox.values), desired=albumentations_bbox)

--- a/tests/pybboxes/types/test_fiftyone_bounding_box.py
+++ b/tests/pybboxes/types/test_fiftyone_bounding_box.py
@@ -29,10 +29,10 @@ def fiftyone_area_computations_expected_output():
     }
 
 
-def test_shift(fiftyone_bounding_box, bbox_shift_amount):
-    actual_output = fiftyone_bounding_box.shift(bbox_shift_amount)
+def test_shift(fiftyone_bounding_box, normalized_bbox_shift_amount):
+    actual_output = fiftyone_bounding_box.shift(normalized_bbox_shift_amount)
     x_tl, y_tl, w, h = fiftyone_bounding_box.values
-    desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
+    desired = (x_tl + normalized_bbox_shift_amount[0], y_tl + normalized_bbox_shift_amount[1], w, h)
 
     assert_almost_equal(actual=actual_output.values, desired=desired)
 

--- a/tests/pybboxes/types/test_fiftyone_bounding_box.py
+++ b/tests/pybboxes/types/test_fiftyone_bounding_box.py
@@ -29,6 +29,14 @@ def fiftyone_area_computations_expected_output():
     }
 
 
+def test_shift(fiftyone_bounding_box, bbox_shift_amount):
+    actual_output = fiftyone_bounding_box.shift(bbox_shift_amount)
+    x_tl, y_tl, w, h = fiftyone_bounding_box.values
+    desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
+
+    assert_almost_equal(actual=actual_output.values, desired=desired)
+
+
 def test_to_albumentations(fiftyone_bounding_box, albumentations_bbox):
     fiftyone2albumentations_bbox = fiftyone_bounding_box.to_albumentations()
     assert_almost_equal(actual=list(fiftyone2albumentations_bbox.values), desired=albumentations_bbox)

--- a/tests/pybboxes/types/test_fiftyone_bounding_box.py
+++ b/tests/pybboxes/types/test_fiftyone_bounding_box.py
@@ -29,7 +29,6 @@ def fiftyone_area_computations_expected_output():
     }
 
 
-
 def test_shift(fiftyone_bounding_box, normalized_bbox_shift_amount):
     actual_output = fiftyone_bounding_box.shift(normalized_bbox_shift_amount)
     x_tl, y_tl, w, h = fiftyone_bounding_box.values
@@ -37,11 +36,10 @@ def test_shift(fiftyone_bounding_box, normalized_bbox_shift_amount):
 
     assert_almost_equal(actual=actual_output.values, desired=desired)
 
-    
+
 def test_from_array(fiftyone_bbox, image_size):
     with pytest.warns(FutureWarning):
         FiftyoneBoundingBox.from_array(fiftyone_bbox, image_size=image_size)
-
 
 
 def test_to_albumentations(fiftyone_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_yolo_bounding_box.py
+++ b/tests/pybboxes/types/test_yolo_bounding_box.py
@@ -34,7 +34,7 @@ def test_shift(yolo_bounding_box, normalized_bbox_shift_amount):
     x_tl, y_tl, w, h = yolo_bounding_box.values
     desired = (x_tl + normalized_bbox_shift_amount[0], y_tl + normalized_bbox_shift_amount[1], w, h)
 
-    print(actual_output, desired, 'Yolo Bounding Box')
+    print(actual_output, desired, "Yolo Bounding Box")
 
     assert_almost_equal(actual=actual_output.values, desired=desired)
 

--- a/tests/pybboxes/types/test_yolo_bounding_box.py
+++ b/tests/pybboxes/types/test_yolo_bounding_box.py
@@ -29,6 +29,14 @@ def yolo_area_computations_expected_output():
     }
 
 
+def test_shift(yolo_bounding_box, bbox_shift_amount):
+    actual_output = yolo_bounding_box.shift(bbox_shift_amount)
+    x_tl, y_tl, w, h = yolo_bounding_box.values
+    desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
+
+    assert_almost_equal(actual=actual_output.values, desired=desired)
+
+
 def test_to_albumentations(yolo_bounding_box, albumentations_bbox):
     yolo2albumentations_bbox = yolo_bounding_box.to_albumentations()
     assert_almost_equal(actual=list(yolo2albumentations_bbox.values), desired=albumentations_bbox)

--- a/tests/pybboxes/types/test_yolo_bounding_box.py
+++ b/tests/pybboxes/types/test_yolo_bounding_box.py
@@ -38,11 +38,10 @@ def test_shift(yolo_bounding_box, normalized_bbox_shift_amount):
 
     assert_almost_equal(actual=actual_output.values, desired=desired)
 
-    
+
 def test_from_array(yolo_bbox, image_size):
     with pytest.warns(FutureWarning):
         YoloBoundingBox.from_array(yolo_bbox, image_size=image_size)
-
 
 
 def test_to_albumentations(yolo_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_yolo_bounding_box.py
+++ b/tests/pybboxes/types/test_yolo_bounding_box.py
@@ -34,6 +34,8 @@ def test_shift(yolo_bounding_box, bbox_shift_amount):
     x_tl, y_tl, w, h = yolo_bounding_box.values
     desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
 
+    print(actual_output, desired, 'Yolo Bounding Box')
+
     assert_almost_equal(actual=actual_output.values, desired=desired)
 
 

--- a/tests/pybboxes/types/test_yolo_bounding_box.py
+++ b/tests/pybboxes/types/test_yolo_bounding_box.py
@@ -29,10 +29,10 @@ def yolo_area_computations_expected_output():
     }
 
 
-def test_shift(yolo_bounding_box, bbox_shift_amount):
-    actual_output = yolo_bounding_box.shift(bbox_shift_amount)
+def test_shift(yolo_bounding_box, normalized_bbox_shift_amount):
+    actual_output = yolo_bounding_box.shift(normalized_bbox_shift_amount)
     x_tl, y_tl, w, h = yolo_bounding_box.values
-    desired = (x_tl + bbox_shift_amount[0], y_tl + bbox_shift_amount[1], w, h)
+    desired = (x_tl + normalized_bbox_shift_amount[0], y_tl + normalized_bbox_shift_amount[1], w, h)
 
     print(actual_output, desired, 'Yolo Bounding Box')
 


### PR DESCRIPTION
Linked with issue #5 

All bounding box types convert to a VocBoundingBox object. The shifting is done in the VOC coordinates, and a new object of same class is being returned. All other properties are kept as passed during the initialisation of the current object.