### PR TITLE
README.md updated with future Python3.8 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Light weight toolkit for bounding boxes providing conversion between bounding bo
 - **voc** : [Pascal VOC](http://host.robots.ox.ac.uk/pascal/VOC/)
 - **yolo** : [YOLO](https://github.com/ultralytics/yolov5)
 
+### Important Notice
+Support for Python<3.8 will be dropped starting version `0.2` though the development for Python3.6 and Python3.7 may 
+continue where it will be developed under version `0.1.x` for future versions. This may introduce; however, certain 
+discrepancies and/or unsupported operations in the `0.1.x` versions. To fully utilize and benefit from the entire 
+package, we recommend using Python3.8 at minimum (`Python>=3.8`).
+
 ## Installation
 
 Through pip (recommended),

--- a/pybboxes/__init__.py
+++ b/pybboxes/__init__.py
@@ -8,4 +8,4 @@ from pybboxes.types import (
     YoloBoundingBox,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/pybboxes/types/base.py
+++ b/pybboxes/types/base.py
@@ -1,7 +1,10 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import List, Tuple, Union
 
 import numpy as np
+
+from pybboxes.utils import find_stack_level
 
 
 class Box:
@@ -136,6 +139,13 @@ class BaseBoundingBox(Box, ABC):
         """
         This method is intended to be "final", and should not be overridden in child classes.
         """
+        warnings.warn(
+            "The functionality of the `from_array()` method is changed from only supporting a single box values to "
+            "support (arbitrary) n-dimensional array of box values starting from 0.2 onward "
+            "requiring Python3.8 or higher.",
+            FutureWarning,
+            stacklevel=find_stack_level(),
+        )
         if len(ar) != 4:
             raise ValueError(f"Given array must be length of 4, got length {len(ar)}.")
         return cls(*ar, **kwargs)

--- a/pybboxes/utils.py
+++ b/pybboxes/utils.py
@@ -1,4 +1,6 @@
 import importlib.util
+import inspect
+import os.path
 from pathlib import Path
 from typing import Union
 
@@ -8,3 +10,28 @@ def import_module(module_name: str, filepath: Union[str, Path]):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def find_stack_level() -> int:
+    """
+    Taken and adapted from pandas exception utility module.
+    ref:
+    https://github.com/pandas-dev/pandas/blob/22cb3793b47ed5b1f98156b58e0bfc109acebdc9/pandas/util/_exceptions.py#L27
+    """
+
+    import pybboxes as pbx
+
+    pkg_dir = os.path.dirname(pbx.__file__)
+    test_dir = os.path.join(pkg_dir, "tests")
+
+    # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
+    frame = inspect.currentframe()
+    n = 0
+    while frame:
+        fname = inspect.getfile(frame)
+        if fname.startswith(pkg_dir) and not fname.startswith(test_dir):
+            frame = frame.f_back
+            n += 1
+        else:
+            break
+    return n

--- a/tests/pybboxes/types/test_albumentations_bounding_box.py
+++ b/tests/pybboxes/types/test_albumentations_bounding_box.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pybboxes import BoundingBox
+from pybboxes import AlbumentationsBoundingBox, BoundingBox
 from tests.utils import assert_almost_equal
 
 
@@ -27,6 +27,11 @@ def albumentations_area_computations_expected_output():
         "ratio": 1.092,
         "difference": 7084,
     }
+
+
+def test_from_array(albumentations_bbox, image_size):
+    with pytest.warns(FutureWarning):
+        AlbumentationsBoundingBox.from_array(albumentations_bbox, image_size=image_size)
 
 
 def test_to_coco(albumentations_bounding_box, coco_bbox):

--- a/tests/pybboxes/types/test_coco_bounding_box.py
+++ b/tests/pybboxes/types/test_coco_bounding_box.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pybboxes import BoundingBox
+from pybboxes import BoundingBox, CocoBoundingBox
 from tests.utils import assert_almost_equal
 
 
@@ -27,6 +27,11 @@ def coco_area_computations_expected_output():
         "ratio": 1.0023946360153257,
         "difference": 1080,
     }
+
+
+def test_from_array(coco_bbox, image_size):
+    with pytest.warns(FutureWarning):
+        CocoBoundingBox.from_array(coco_bbox, image_size=image_size)
 
 
 def test_to_coco(coco_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_fiftyone_bounding_box.py
+++ b/tests/pybboxes/types/test_fiftyone_bounding_box.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pybboxes import BoundingBox
+from pybboxes import BoundingBox, FiftyoneBoundingBox
 from tests.utils import assert_almost_equal
 
 
@@ -27,6 +27,11 @@ def fiftyone_area_computations_expected_output():
         "ratio": 0.9266528925619835,
         "difference": 6967,
     }
+
+
+def test_from_array(fiftyone_bbox, image_size):
+    with pytest.warns(FutureWarning):
+        FiftyoneBoundingBox.from_array(fiftyone_bbox, image_size=image_size)
 
 
 def test_to_albumentations(fiftyone_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_voc_bounding_box.py
+++ b/tests/pybboxes/types/test_voc_bounding_box.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pybboxes import BoundingBox
+from pybboxes import BoundingBox, VocBoundingBox
 from tests.utils import assert_almost_equal
 
 
@@ -27,6 +27,11 @@ def voc_area_computations_expected_output():
         "ratio": 0.9884556855748544,
         "difference": 438,
     }
+
+
+def test_from_array(voc_bbox, image_size):
+    with pytest.warns(FutureWarning):
+        VocBoundingBox.from_array(voc_bbox, image_size=image_size)
 
 
 def test_to_albumentations(voc_bounding_box, albumentations_bbox):

--- a/tests/pybboxes/types/test_yolo_bounding_box.py
+++ b/tests/pybboxes/types/test_yolo_bounding_box.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pybboxes import BoundingBox
+from pybboxes import BoundingBox, YoloBoundingBox
 from tests.utils import assert_almost_equal
 
 
@@ -27,6 +27,11 @@ def yolo_area_computations_expected_output():
         "ratio": 0.9266528925619835,
         "difference": 6263,
     }
+
+
+def test_from_array(yolo_bbox, image_size):
+    with pytest.warns(FutureWarning):
+        YoloBoundingBox.from_array(yolo_bbox, image_size=image_size)
 
 
 def test_to_albumentations(yolo_bounding_box, albumentations_bbox):


### PR DESCRIPTION
Closes #14.

- Future warning and tests are added for `from_array()`.
- Version bumped to 0.1.1.