### PR TITLE
add manifest file to include reqs.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_long_description():
 
 
 def get_requirements():
-    with open("requirements.txt") as f:
+    with open("requirements.txt", encoding="utf8") as f:
         return f.read().splitlines()
 
 


### PR DESCRIPTION
currently, conda-forge tests fail for pybboxes since requirements.txt file is not included in sdist: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=527405&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=934

this pr:
- adds requirements.txt in sdist
- sets the encoding for open() to UTF-8 per [PEP597](https://www.python.org/dev/peps/pep-0597).

related pr in sahi: https://github.com/obss/sahi/pull/217